### PR TITLE
Treat NaN values the same as NA values

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # readr (development version)
 
+## Breaking changes
+
+* `write_*()` functions now output any NaN values in the same way as NA values,
+  controlled by the `na=` argument. (#1082).
+
+## Additional features and fixes
+
 * `write_excel_csv()` no longer outputs a byte order mark when appending to a file (#1075).
 
 * The `read_*` functions now close properly all connections, including on 

--- a/src/write_delim.cpp
+++ b/src/write_delim.cpp
@@ -191,10 +191,8 @@ void stream_delim(
   case REALSXP: {
     double value = REAL(x)[i];
     if (!R_FINITE(value)) {
-      if (ISNA(value)) {
+      if (ISNA(value) || ISNAN(value)) {
         output << na;
-      } else if (ISNAN(value)) {
-        output << "NaN";
       } else if (value > 0) {
         output << "Inf";
       } else {

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -30,7 +30,7 @@ test_that("read_delim/csv/tsv and write_delim round trip special chars", {
 
 test_that("special floating point values translated to text", {
   df <- data.frame(x = c(NaN, NA, Inf, -Inf))
-  expect_equal(format_csv(df), "x\nNaN\nNA\nInf\n-Inf\n")
+  expect_equal(format_csv(df), "x\nNA\nNA\nInf\n-Inf\n")
 })
 
 test_that("logical values give long names", {


### PR DESCRIPTION
Previously NaN values were always output as NaN, this makes them use the
value of the `na` argument, which is behavior consistent with
write.csv() and data.table::fwrite().

Fixes #1082